### PR TITLE
Use TokenId where possible

### DIFF
--- a/contracts/cosmons/helpers.ts
+++ b/contracts/cosmons/helpers.ts
@@ -234,7 +234,7 @@ interface CW721Instance {
   allTokens: (startAfter?: string, limit?: number ) => Promise<TokensResponse>
 
   // actions
-  mint: (tokenId: TokenId, owner:string, name:string, description?: string, image?: string) => Promise<string>
+  mint: (tokenId: TokenId, owner: string, name: string, description?: string, image?: string) => Promise<string>
   transferNft: (recipient: string, tokenId: TokenId) => Promise<string>
   approve: (spender: string, tokenId: TokenId, expires?: Expiration) => Promise<string>
   approveAll: (operator: string, expires?: Expiration) => Promise<string>
@@ -289,16 +289,16 @@ const CW721 = (client: SigningCosmWasmClient): CW721Contract => {
       return client.queryContractSmart(contractAddress, {contract_info: { }});
     };
 
-    const nftInfo = async (token_id: string): Promise<any> => {
+    const nftInfo = async (token_id: TokenId): Promise<any> => {
       return client.queryContractSmart(contractAddress, {nft_info: { token_id }});
     }  
 
-    const allNftInfo = async (token_id: string): Promise<any> => {
+    const allNftInfo = async (token_id: TokenId): Promise<any> => {
       return client.queryContractSmart(contractAddress, {all_nft_info: { token_id }});
     } 
 
     // TODO: Need help here
-    const ownerOf = async (token_id: string): Promise<any> => {
+    const ownerOf = async (token_id: TokenId): Promise<any> => {
         return await client.queryContractSmart(contractAddress, {owner_of: {token_id}});
     }
 
@@ -309,14 +309,14 @@ const CW721 = (client: SigningCosmWasmClient): CW721Contract => {
     };
 */
     // mints tokens, returns ?
-    const mint = async (token_id: string, owner: string, name:string, description?:string, image?:string): Promise<string> => {
+    const mint = async (token_id: TokenId, owner: string, name:string, description?: string, image?: string): Promise<string> => {
       const result = await client.execute(contractAddress, { mint: { token_id, owner, name, description, image }});
       return result.transactionHash;
     }
    
    
     // transfers ownership, returns transactionHash
-    const transferNft = async (recipient: string, token_id: string): Promise<string> => {
+    const transferNft = async (recipient: string, token_id: TokenId): Promise<string> => {
       const result = await client.execute(contractAddress, {transfer_nft: {recipient, token_id}});
       return result.transactionHash;
     }
@@ -335,7 +335,7 @@ const CW721 = (client: SigningCosmWasmClient): CW721Contract => {
       return client.queryContractSmart(contractAddress, {all_tokens: { start_after, limit}});
     }
 
-    const approve = async (spender: string, token_id: string, expires?: Expiration): Promise<string> => {
+    const approve = async (spender: string, token_id: TokenId, expires?: Expiration): Promise<string> => {
       const result = await client.execute(contractAddress, {approve: {spender, token_id, expires}});
       return result.transactionHash;
     }
@@ -345,7 +345,7 @@ const CW721 = (client: SigningCosmWasmClient): CW721Contract => {
       return result.transactionHash
     }
     
-    const revoke = async (spender: string, token_id: string): Promise<string> => {
+    const revoke = async (spender: string, token_id: TokenId): Promise<string> => {
       const result = await client.execute(contractAddress, {revoke: {spender, token_id}});
       return result.transactionHash;
     }

--- a/contracts/cosmons/helpers.ts
+++ b/contracts/cosmons/helpers.ts
@@ -182,7 +182,7 @@ interface InitMsg {
 }
 // Better to use this interface?
 interface MintMsg {
-  readonly token_id: string
+  readonly token_id: TokenId
   readonly owner: string
   readonly name: string
   readonly description?: string


### PR DESCRIPTION
* Use `tokenId = TokenId` in public API
* Use `token_id = TokenId` elsewhere